### PR TITLE
Use consumerProguardFiles for library module

### DIFF
--- a/nestedscrollcoordinatorlayout/build.gradle
+++ b/nestedscrollcoordinatorlayout/build.gradle
@@ -22,7 +22,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 }


### PR DESCRIPTION
Since this a library module the proguard setting should be `consumerProguardFiles`. It doesn't affect functionality because this project has no proguard rules but incase there were it should be consumerProguardFiles.